### PR TITLE
WIP: Ember Tests

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
     "ember": "~2.8.0",
     "ember-cli-shims": "0.1.1",
     "moment": "momentjs#^2.14.1",
-    "bootstrap": "~3.3.5"
+    "bootstrap": "~3.3.5",
+    "jquery-mockjax": "2.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "^2.8.0",
+    "ember-data-factory-guy": "2.7.10",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",

--- a/tests/factories/blog.js
+++ b/tests/factories/blog.js
@@ -1,0 +1,16 @@
+import FactoryGuy from 'ember-data-factory-guy';
+
+FactoryGuy.define('blog', {
+  default: {
+    title: 'Post Title',
+    body: '<p>Blog post body content.</p>',
+    publishedAt: '2016-06-19 00:00:00',
+    status: 'Published',
+  },
+  blogRecipe: {
+    title: 'Recipe Title',
+    body: '<p>Blog recipe body content.</p>',
+    publishedAt: '2016-05-07 00:00:00',
+    status: 'Draft'
+  }
+});

--- a/tests/factories/blog.js
+++ b/tests/factories/blog.js
@@ -4,8 +4,8 @@ FactoryGuy.define('blog', {
   default: {
     title: 'Post Title',
     body: '<p>Blog post body content.</p>',
-    publishedAt: '2016-06-19 00:00:00',
-    status: 'Published',
+    publishedAt: '2015-09-01 00:00:00',
+    status: 'Published'
   },
   blogRecipe: {
     title: 'Recipe Title',

--- a/tests/factories/category.js
+++ b/tests/factories/category.js
@@ -1,0 +1,7 @@
+import FactoryGuy from 'ember-data-factory-guy';
+
+FactoryGuy.define('category', {
+  default: { name: 'Post' },
+  categoryRecipe: { name: 'Recipe' },
+  categoryReview: { name: 'Review' }
+});

--- a/tests/factories/user.js
+++ b/tests/factories/user.js
@@ -1,0 +1,22 @@
+import FactoryGuy from 'ember-data-factory-guy';
+
+FactoryGuy.define('user', {
+  default: {
+    email: 'admin+user@example.com',
+    firstName: 'Super',
+    lastName: 'Admin',
+    role: 'Admin'
+  },
+  firstBlogger: {
+    email: 'blog+user+1@example.com',
+    firstName: 'First',
+    lastName: 'Blogger',
+    role: 'Editor'
+  },
+  secondBlogger: {
+    email: 'blog+user+2@example.com',
+    firstName: 'Second',
+    lastName: 'Blogger',
+    role: 'Editor'
+  }
+});

--- a/tests/integration/components/activity-streams-item-test.js
+++ b/tests/integration/components/activity-streams-item-test.js
@@ -5,20 +5,44 @@ moduleForComponent('activity-streams-item', 'Integration | Component | activity 
   integration: true
 });
 
-test('it renders', function(assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+const dateNow = new Date();
+const timeNow = dateNow.getSeconds();
+const createdAt = dateNow.setSeconds(timeNow - 30);
+const activity = {
+  author_id: 1,
+  author: 'Foodie Blogger',
+  blog_id: 1,
+  action: 'published',
+  created_at: createdAt,
+  category_name: 'Recipe',
+  deleted: false
+};
 
-  this.render(hbs`{{activity-streams-item}}`);
+test('it renders an activity streams item', function(assert) {
+  assert.expect(8);
 
-  assert.equal(this.$().text().trim(), '');
+  this.set('activity', activity);
+  this.render(hbs`{{activity-streams-item activity=activity}}`);
 
-  // Template block usage:
-  this.render(hbs`
-    {{#activity-streams-item}}
-      template block text
-    {{/activity-streams-item}}
-  `);
+  assert.equal(this.$('li').text().trim(), 'Foodie Blogger\n' +
+                                           'published a\n' +
+                                           '  recipe\n' +
+                                           'a few seconds ago.');
+  assert.equal(this.$('li a:eq(0)').text(), 'Foodie Blogger');
+  assert.equal(this.$('li a:eq(1)').text(), 'recipe');
+  assert.equal(this.$('li time').text(), 'a few seconds ago');
 
-  assert.equal(this.$().text().trim(), 'template block text');
+  activity.action = 'deleted';
+  activity.deleted = true;
+
+  this.set('activity', activity);
+  this.render(hbs`{{activity-streams-item activity=activity}}`);
+
+  assert.equal(this.$('li').text().trim(), 'Foodie Blogger\n' +
+                                           'deleted a\n' +
+                                           '  recipe\n' +
+                                           'a few seconds ago.');
+  assert.equal(this.$('li a:eq(0)').text(), 'Foodie Blogger');
+  assert.equal(this.$('li strong').text(), 'recipe');
+  assert.equal(this.$('li time').text(), 'a few seconds ago');
 });

--- a/tests/integration/components/activity-streams-item-test.js
+++ b/tests/integration/components/activity-streams-item-test.js
@@ -19,7 +19,7 @@ const activity = {
 };
 
 test('it renders an activity streams item', function(assert) {
-  assert.expect(8);
+  assert.expect(9);
 
   this.set('activity', activity);
   this.render(hbs`{{activity-streams-item activity=activity}}`);
@@ -42,7 +42,8 @@ test('it renders an activity streams item', function(assert) {
                                            'deleted a\n' +
                                            '  recipe\n' +
                                            'a few seconds ago.');
-  assert.equal(this.$('li a:eq(0)').text(), 'Foodie Blogger');
-  assert.equal(this.$('li strong').text(), 'recipe');
+  assert.equal(this.$('li a:eq(0)').text(), '');
+  assert.equal(this.$('li strong:eq(0)').text(), 'Foodie Blogger');
+  assert.equal(this.$('li strong:eq(1)').text(), 'recipe');
   assert.equal(this.$('li time').text(), 'a few seconds ago');
 });

--- a/tests/integration/components/activity-streams-test.js
+++ b/tests/integration/components/activity-streams-test.js
@@ -5,20 +5,40 @@ moduleForComponent('activity-streams', 'Integration | Component | activity strea
   integration: true
 });
 
-test('it renders', function(assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+const dateNow = new Date();
+const timeNow = dateNow.getSeconds();
+const firstCreatedAt = dateNow.setSeconds(timeNow - 30);
+const firstActivity = {
+  author_id: 1,
+  author: 'Foodie Blogger',
+  blog_id: 1,
+  action: 'published',
+  created_at: firstCreatedAt,
+  category_name: 'Recipe',
+  deleted: false
+};
+const secondCreatedAt = dateNow.setSeconds(timeNow - 7200);
+const secondActivity = {
+  author_id: 2,
+  author: 'Foodie Reviewer',
+  blog_id: 2,
+  action: 'deleted',
+  created_at: secondCreatedAt,
+  category_name: 'Review',
+  deleted: false
+};
+const model = [firstActivity, secondActivity];
 
-  this.render(hbs`{{activity-streams}}`);
+test('it renders list of activity streams items', function(assert) {
+  assert.expect(1);
 
-  assert.equal(this.$().text().trim(), '');
+  this.set('model', model);
+  this.render(hbs`{{activity-streams activityStreams=model}}`);
 
-  // Template block usage:
-  this.render(hbs`
-    {{#activity-streams}}
-      template block text
-    {{/activity-streams}}
-  `);
-
-  assert.equal(this.$().text().trim(), 'template block text');
+  assert.equal(this.$('.activity-streams-list ul').text().trim(), 'Foodie Blogger\n' +
+                                                                  'published a\n' +
+                                                                  '  recipe\na few seconds ago.\n\n' +
+                                                                  '        Foodie Reviewer\n' +
+                                                                  'deleted a\n' +
+                                                                  '  review\n2 hours ago.');
 });

--- a/tests/integration/components/activity-streams-test.js
+++ b/tests/integration/components/activity-streams-test.js
@@ -38,7 +38,7 @@ test('it renders list of activity streams items', function(assert) {
   assert.equal(this.$('.activity-streams-list ul').text().trim(), 'Foodie Blogger\n' +
                                                                   'published a\n' +
                                                                   '  recipe\na few seconds ago.\n\n' +
-                                                                  '        Foodie Reviewer\n' +
+                                                                  '          Foodie Reviewer\n' +
                                                                   'deleted a\n' +
                                                                   '  review\n2 hours ago.');
 });

--- a/tests/integration/components/admin-blog-form-test.js
+++ b/tests/integration/components/admin-blog-form-test.js
@@ -1,24 +1,228 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { make, manualSetup } from 'ember-data-factory-guy';
 
-moduleForComponent('admin-blog-form', 'Integration | Component | admin blog form', {
-  integration: true
+const sessionStub = Ember.Service.extend({
+  session: {
+    content: {
+      authenticated: {
+        userId: 1,
+        token: 'S4mpl3T0k3n',
+        role: 'Admin',
+        email: 'admin+user@example.com',
+        firstName: 'Admin',
+        lastName: 'User'
+      }
+    }
+  }
+});
+let origConfirm;
+let transitionToAdminBlogs = '';
+const routeStub = Ember.Service.extend({
+  transitionTo() {
+    transitionToAdminBlogs = 'admin.blogs';
+  }
 });
 
-test('it renders', function(assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+moduleForComponent('admin-blog-form', 'Integration | Component | admin blog form', {
+  integration: true,
+  beforeEach() {
+    this.register('service:session', sessionStub);
+    this.inject.service('session', { as: 'session'});
+    this.register('service:-routing', routeStub);
+    origConfirm = window.confirm;
+    manualSetup(this.container);
+  },
+  afterEach() {
+    window.confirm = origConfirm;
+    transitionToAdminBlogs = '';
+  }
+});
+
+test('display the "Cancel" button', function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`{{admin-blog-form showCancelButton=true}}`);
+
+  assert.equal(this.$('.btn-danger').text(), 'Cancel');
+});
+
+test('display the "Delete" button', function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`{{admin-blog-form showDeleteButton=true}}`);
+
+  assert.equal(this.$('.btn-danger').text(), 'Delete');
+});
+
+test('display the "window.confirm" dialog box when "Cancel" or "Delete" button is clicked', function(assert) {
+  assert.expect(2);
+
+  let displayConfirm = false;
+
+  // Stub the window.confirm()
+  window.confirm = function() {
+    displayConfirm = true;
+  };
+
+  this.render(hbs`{{admin-blog-form showCancelButton=true}}`);
+  this.$('.btn-danger').click();
+
+  assert.equal(displayConfirm, true);
+  displayConfirm = false;
+
+  this.render(hbs`{{admin-blog-form showDeleteButton=true}}`);
+  this.$('.btn-danger').click();
+
+  assert.equal(displayConfirm, true);
+});
+
+test('do nothing when "Cancel" or "Delete" button is clicked and "window.confirm" dialog box returns false', function(assert) {
+  assert.expect(3);
+
+  // Stub the window.confirm()
+  window.confirm = function() {
+    return false;
+  };
+
+  assert.equal(transitionToAdminBlogs, '');
+
+  this.render(hbs`{{admin-blog-form showCancelButton=true}}`);
+  this.$('.btn-danger').click();
+
+  assert.equal(transitionToAdminBlogs, '');
+
+  this.render(hbs`{{admin-blog-form showDeleteButton=true}}`);
+  this.$('.btn-danger').click();
+
+  assert.equal(transitionToAdminBlogs, '');
+});
+
+test('display the Blogs page when "Cancel" button is clicked and "window.confirm" dialog box returns true', function(assert) {
+  assert.expect(2);
+
+  // Stub the window.confirm()
+  window.confirm = function() {
+    return true;
+  };
+
+  assert.equal(transitionToAdminBlogs, '');
+
+  this.render(hbs`{{admin-blog-form showCancelButton=true}}`);
+  this.$('.btn-danger').click();
+
+  assert.equal(transitionToAdminBlogs, 'admin.blogs');
+});
+
+test('init "New Blog" form with default button states and text inputs', function(assert) {
+  assert.expect(5);
+
+  this.render(hbs`{{admin-blog-form showDeleteButton=true}}`);
+
+  assert.equal(this.$('.btn.active:eq(0)').text(), 'Post');
+  assert.equal(this.$('#blog-title').val(), '');
+  assert.equal(this.$('#blog-body').val(), '');
+  assert.equal(this.$('#blog-published-date').val(), '');
+  assert.equal(this.$('.btn.active:eq(1)').text(), 'Published');
+});
+
+test('set the blog type when "Type" button is clicked ', function(assert) {
+  assert.expect(4);
 
   this.render(hbs`{{admin-blog-form}}`);
+  assert.equal(this.$('.btn.active:eq(0)').text(), 'Post');
 
-  assert.equal(this.$().text().trim(), '');
+  this.$('.btn:eq(1)').click();
+  assert.equal(this.$('.btn.active:eq(0)').text(), 'Recipe');
 
-  // Template block usage:
-  this.render(hbs`
-    {{#admin-blog-form}}
-      template block text
-    {{/admin-blog-form}}
-  `);
+  this.$('.btn:eq(2)').click();
+  assert.equal(this.$('.btn.active:eq(0)').text(), 'Review');
 
-  assert.equal(this.$().text().trim(), 'template block text');
+  this.$('.btn:eq(0)').click();
+  assert.equal(this.$('.btn.active:eq(0)').text(), 'Post');
+});
+
+test('set blog status when "Status" button is clicked', function(assert) {
+  assert.expect(3);
+
+  this.render(hbs`{{admin-blog-form}}`);
+  assert.equal(this.$('.btn.active:eq(1)').text(), 'Published');
+
+  this.$('.btn:eq(4)').click();
+  assert.equal(this.$('.btn.active:eq(1)').text(), 'Draft');
+
+  this.$('.btn:eq(3)').click();
+  assert.equal(this.$('.btn.active:eq(1)').text(), 'Published');
+});
+
+test('display errors when "New Blog" form is submitted with empty input text fields', function(assert) {
+  assert.expect(8);
+
+  this.render(hbs`{{admin-blog-form method='create'}}`);
+
+  assert.equal(this.$('.alert').length, 0);
+  assert.equal(this.$('#blog-title').hasClass('error'), false);
+  assert.equal(this.$('#blog-body').hasClass('error'), false);
+  assert.equal(this.$('#blog-published-date').hasClass('error'), false);
+
+  this.$('[type=submit]').click();
+
+  assert.equal(this.$('.alert').text(), 'Title is required.Body is required.Published date is required.');
+  assert.equal(this.$('#blog-title').hasClass('error'), true);
+  assert.equal(this.$('#blog-body').hasClass('error'), true);
+  assert.equal(this.$('#blog-published-date').hasClass('error'), true);
+});
+
+test('set "Edit Blog" form with the existing blog data', function(assert) {
+  assert.expect(5);
+
+  let recipe = make('categoryRecipe');
+  let model = make('blogRecipe', { categoryId: recipe.get('id') });
+
+  this.set('model', model);
+  this.render(hbs`{{admin-blog-form blog=model}}`);
+
+  assert.equal(this.$('.btn.active:eq(0)').text(), 'Recipe');
+  assert.equal(this.$('#blog-title').val(), 'Recipe Title');
+  assert.equal(this.$('#blog-body').val(), '<p>Blog recipe body content.</p>');
+  assert.equal(this.$('#blog-published-date').val(), '2016-05-07');
+  assert.equal(this.$('.btn.active:eq(1)').text(), 'Draft');
+});
+
+test('submit blog form when "Save" button is clicked', function(assert) {
+  assert.expect(1);
+
+  this.on('stubSubmitBlogForm', function() {
+    // This does not triggger the stubbed form action
+    console.log('Stubbed submit blog form is triggered.');
+  });
+
+  this.render(hbs`{{admin-blog-form submitBlogForm=stubSubmitBlogForm}}`);
+
+  assert.equal(this.$('.btn.btn-success').length, 1);
+
+  this.$('.btn.btn-success').click();
+});
+
+test('should delete an existing blog when "Delete" button is clicked', function(assert) {
+  assert.expect(2);
+
+  let recipe = make('category');
+  let model = make('blog', { categoryId: recipe.get('id') });
+  let blogShouldBeDeleted = false;
+
+  // Stub the window.confirm()
+  window.confirm = function() {
+    blogShouldBeDeleted = true;
+  };
+
+  this.set('model', model);
+  this.render(hbs`{{admin-blog-form blog=model showDeleteButton=true}}`);
+
+  assert.equal(this.$('#blog-title').val(), 'Post Title');
+
+  this.$('.btn.btn-danger').click();
+
+  assert.equal(blogShouldBeDeleted, true);
 });

--- a/tests/integration/components/admin-blogs-list-test.js
+++ b/tests/integration/components/admin-blogs-list-test.js
@@ -1,24 +1,94 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import { make, manualSetup } from 'ember-data-factory-guy';
+
+let role = 'Admin';
+let sessionStub;
 
 moduleForComponent('admin-blogs-list', 'Integration | Component | admin blogs list', {
-  integration: true
+  integration: true,
+  beforeEach() {
+    sessionStub = Ember.Service.extend({
+      session: {
+        content: {
+          authenticated: {
+            userId: 1,
+            token: 'S4mpl3T0k3n',
+            role: role,
+            email: 'admin+user@example.com',
+            firstName: 'Admin',
+            lastName: 'User'
+          }
+        }
+      }
+    });
+
+    this.register('service:session', sessionStub);
+    this.inject.service('session', { as: 'session'});
+    manualSetup(this.container);
+  }
 });
 
-test('it renders', function(assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+test('display message when no blogs is found', function(assert) {
+  assert.expect(1);
 
   this.render(hbs`{{admin-blogs-list}}`);
 
-  assert.equal(this.$().text().trim(), '');
+  assert.equal(this.$().text().trim(), 'There are no blogs found. Create a new blog instead.');
+});
 
-  // Template block usage:
-  this.render(hbs`
-    {{#admin-blogs-list}}
-      template block text
-    {{/admin-blogs-list}}
-  `);
+test('display list of blogs when user is an Admin', function(assert) {
+  // Set role for next test
+  role = 'Editor';
 
-  assert.equal(this.$().text().trim(), 'template block text');
+  assert.expect(10);
+
+  let firstBlogger = make('firstBlogger');
+  let post = make('category');
+  let postBlog = make('blog', { user: firstBlogger, category: post });
+
+  let secondBlogger = make('secondBlogger');
+  let recipe  = make('categoryRecipe');
+  let recipeBlog = make('blogRecipe', { user: secondBlogger, category: recipe });
+
+  this.set('model', [postBlog, recipeBlog]);
+
+  this.render(hbs`{{admin-blogs-list blogs=model}}`);
+
+  assert.equal(this.$('tr:eq(0) td').text().trim(), 'Title Post Title');
+  assert.equal(this.$('tr:eq(1) td').text().trim(), 'Author First Blogger');
+  assert.equal(this.$('tr:eq(2) td').text().trim(), 'Published September 1, 2015');
+  assert.equal(this.$('tr:eq(3) td:eq(0)').text().trim(), 'Type Post');
+  assert.equal(this.$('tr:eq(3) td:eq(1)').text().trim(), 'Status Published');
+
+  assert.equal(this.$('tr:eq(4) td').text().trim(), 'Title Recipe Title');
+  assert.equal(this.$('tr:eq(5) td').text().trim(), 'Author Second Blogger');
+  assert.equal(this.$('tr:eq(6) td').text().trim(), 'Published May 7, 2016');
+  assert.equal(this.$('tr:eq(7) td:eq(0)').text().trim(), 'Type Recipe');
+  assert.equal(this.$('tr:eq(7) td:eq(1)').text().trim(), 'Status Draft');
+});
+
+test('display list of blogs when user is an Editor', function(assert) {
+  assert.expect(8);
+
+  let post = make('category');
+  let postBlog = make('blog', { category: post });
+
+  let recipe  = make('categoryRecipe');
+  let recipeBlog = make('blogRecipe', { category: recipe });
+
+  this.set('model', [postBlog, recipeBlog]);
+
+  this.render(hbs`{{admin-blogs-list blogs=model}}`);
+
+  assert.equal(this.$('tr:eq(0) td').text().trim(), 'Title Post Title');
+  assert.equal(this.$('tr:eq(1) td').text().trim(), 'Published September 1, 2015');
+  assert.equal(this.$('tr:eq(2) td:eq(0)').text().trim(), 'Type Post');
+  assert.equal(this.$('tr:eq(2) td:eq(1)').text().trim(), 'Status Published');
+
+  assert.equal(this.$('tr:eq(3) td').text().trim(), 'Title Recipe Title');
+  assert.equal(this.$('tr:eq(4) td').text().trim(), 'Published May 7, 2016');
+  assert.equal(this.$('tr:eq(5) td:eq(0)').text().trim(), 'Type Recipe');
+  assert.equal(this.$('tr:eq(5) td:eq(1)').text().trim(), 'Status Draft');
 });

--- a/tests/integration/components/admin-dashboard-content-test.js
+++ b/tests/integration/components/admin-dashboard-content-test.js
@@ -1,24 +1,56 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
+let role = 'Admin';
+let sessionStub;
+
 moduleForComponent('admin-dashboard-content', 'Integration | Component | admin dashboard content', {
-  integration: true
+  integration: true,
+  beforeEach() {
+    sessionStub = Ember.Service.extend({
+      session: {
+        content: {
+          authenticated: {
+            userId: 1,
+            token: 'S4mpl3T0k3n',
+            role: role,
+            email: 'admin+user@example.com',
+            firstName: 'Admin',
+            lastName: 'User'
+          }
+        }
+      }
+    });
+
+    this.register('service:session', sessionStub);
+    this.inject.service('session', { as: 'session'});
+  }
 });
 
-test('it renders', function(assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+test('displays the dashboard content for admin user', function(assert) {
+  // Set role for next test
+  role = 'Editor';
+
+  assert.expect(6);
 
   this.render(hbs`{{admin-dashboard-content}}`);
 
-  assert.equal(this.$().text().trim(), '');
+  assert.equal(this.$('strong:eq(0)').text().trim(), 'Manage Users');
+  assert.equal(this.$('a:eq(0)').text().trim(), 'View Users');
+  assert.equal(this.$('a:eq(1)').text().trim(), 'New User');
 
-  // Template block usage:
-  this.render(hbs`
-    {{#admin-dashboard-content}}
-      template block text
-    {{/admin-dashboard-content}}
-  `);
+  assert.equal(this.$('strong:eq(1)').text().trim(), 'Manage Blogs');
+  assert.equal(this.$('a:eq(2)').text().trim(), 'View Blogs');
+  assert.equal(this.$('a:eq(3)').text().trim(), 'New Blog');
+});
 
-  assert.equal(this.$().text().trim(), 'template block text');
+test('displays the dashboard content for editor', function(assert) {
+  assert.expect(3);
+
+  this.render(hbs`{{admin-dashboard-content}}`);
+
+  assert.equal(this.$('strong:eq(0)').text().trim(), 'Manage Blogs');
+  assert.equal(this.$('a:eq(0)').text().trim(), 'View Blogs');
+  assert.equal(this.$('a:eq(1)').text().trim(), 'New Blog');
 });

--- a/tests/integration/components/admin-page-title-test.js
+++ b/tests/integration/components/admin-page-title-test.js
@@ -5,20 +5,32 @@ moduleForComponent('admin-page-title', 'Integration | Component | admin page tit
   integration: true
 });
 
-test('it renders', function(assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+test('displays an admin page header with "New" and "Back" buttons', function(assert) {
+  assert.expect(3);
 
-  this.render(hbs`{{admin-page-title}}`);
+  this.render(hbs`{{admin-page-title title='Edit Blog' newButtonTitle='New Blog' newButton=true backButton=true}}`);
 
-  assert.equal(this.$().text().trim(), '');
+  assert.equal(this.$().text().trim(), "Edit Blog\n      Back\n      New Blog");
+  assert.equal(this.$('a').text().trim(), 'New Blog');
+  assert.equal(this.$('button').text().trim(), 'Back');
+});
 
-  // Template block usage:
-  this.render(hbs`
-    {{#admin-page-title}}
-      template block text
-    {{/admin-page-title}}
-  `);
+test('displays an admin page header with "New" button and without "Back" button', function(assert) {
+  assert.expect(3);
 
-  assert.equal(this.$().text().trim(), 'template block text');
+  this.render(hbs`{{admin-page-title title='Blogs' newButtonTitle='New Blog' newButton=true}}`);
+
+  assert.equal(this.$().text().trim(), "Blogs\n      New Blog");
+  assert.equal(this.$('a').text().trim(), 'New Blog');
+  assert.equal(this.$('button').text().trim(), '');
+});
+
+test('displays an admin page header without the "New" and "Back" buttons', function(assert) {
+  assert.expect(3);
+
+  this.render(hbs`{{admin-page-title title='Blogs'}}`);
+
+  assert.equal(this.$().text().trim(), 'Blogs');
+  assert.equal(this.$('a').text().trim(), '');
+  assert.equal(this.$('button').text().trim(), '');
 });

--- a/tests/integration/components/app-footer-test.js
+++ b/tests/integration/components/app-footer-test.js
@@ -5,20 +5,10 @@ moduleForComponent('app-footer', 'Integration | Component | app footer', {
   integration: true
 });
 
-test('it renders', function(assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+test('displays footer', function(assert) {
+  assert.expect(1);
 
   this.render(hbs`{{app-footer}}`);
 
-  assert.equal(this.$().text().trim(), '');
-
-  // Template block usage:
-  this.render(hbs`
-    {{#app-footer}}
-      template block text
-    {{/app-footer}}
-  `);
-
-  assert.equal(this.$().text().trim(), 'template block text');
+  assert.equal(this.$().text().trim(), 'Foodie | Ora HQ © 2016');
 });

--- a/tests/integration/components/nav-bar-test.js
+++ b/tests/integration/components/nav-bar-test.js
@@ -1,24 +1,83 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
+let authUser = false;
+let role = 'Admin';
+let sessionStub;
+
 moduleForComponent('nav-bar', 'Integration | Component | nav bar', {
-  integration: true
+  integration: true,
+  beforeEach() {
+    sessionStub = Ember.Service.extend({
+      isAuthenticated: authUser,
+      session: {
+        content: {
+          authenticated: {
+            userId: 1,
+            token: 'S4mpl3T0k3n',
+            role: role,
+            email: 'signed+user@example.com',
+            firstName: 'Signed',
+            lastName: 'User'
+          }
+        }
+      }
+    });
+
+    this.register('service:session', sessionStub);
+    this.inject.service('session', { as: 'session'});
+  }
 });
 
-test('it renders', function(assert) {
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
+test('displays nav bar for guest user', function(assert) {
+  // Set authUser for next test
+  authUser = true;
+
+  assert.expect(6);
 
   this.render(hbs`{{nav-bar}}`);
 
-  assert.equal(this.$().text().trim(), '');
+  assert.equal(this.$('.navbar-brand').text().trim(), 'Foodie | Ora HQ');
+  assert.equal(this.$('#navbar a:eq(0)').text().trim(), 'Home');
+  assert.equal(this.$('#navbar a:eq(1)').text().trim(), 'Posts');
+  assert.equal(this.$('#navbar a:eq(2)').text().trim(), 'Recipes');
+  assert.equal(this.$('#navbar a:eq(3)').text().trim(), 'Reviews');
+  assert.equal(this.$('#navbar a:eq(4)').text().trim(), 'Sign In');
+});
 
-  // Template block usage:
-  this.render(hbs`
-    {{#nav-bar}}
-      template block text
-    {{/nav-bar}}
-  `);
+test('displays nav bar for signed user with "Admin" permission', function(assert) {
+  // Set role for next test
+  role = 'Editor';
 
-  assert.equal(this.$().text().trim(), 'template block text');
+  assert.expect(10);
+
+  this.render(hbs`{{nav-bar}}`);
+
+  assert.equal(this.$('.navbar-brand').text().trim(), 'Foodie | Ora HQ');
+  assert.equal(this.$('#navbar a:eq(0)').text().trim(), 'Home');
+  assert.equal(this.$('#navbar a:eq(1)').text().trim(), 'Posts');
+  assert.equal(this.$('#navbar a:eq(2)').text().trim(), 'Recipes');
+  assert.equal(this.$('#navbar a:eq(3)').text().trim(), 'Reviews');
+  assert.equal(this.$('#navbar a:eq(4)').text().trim(), 'Signed User');
+  assert.equal(this.$('#navbar .dropdown-menu a:eq(0)').text().trim(), 'Dashboard');
+  assert.equal(this.$('#navbar .dropdown-menu a:eq(1)').text().trim(), 'Blogs');
+  assert.equal(this.$('#navbar .dropdown-menu a:eq(2)').text().trim(), 'Users');
+  assert.equal(this.$('#navbar .dropdown-menu a:eq(3)').text().trim(), 'Sign Out');
+});
+
+test('displays nav bar for signed user but no "Admin" permission', function(assert) {
+  assert.expect(9);
+
+  this.render(hbs`{{nav-bar}}`);
+
+  assert.equal(this.$('.navbar-brand').text().trim(), 'Foodie | Ora HQ');
+  assert.equal(this.$('#navbar a:eq(0)').text().trim(), 'Home');
+  assert.equal(this.$('#navbar a:eq(1)').text().trim(), 'Posts');
+  assert.equal(this.$('#navbar a:eq(2)').text().trim(), 'Recipes');
+  assert.equal(this.$('#navbar a:eq(3)').text().trim(), 'Reviews');
+  assert.equal(this.$('#navbar a:eq(4)').text().trim(), 'Signed User');
+  assert.equal(this.$('#navbar .dropdown-menu a:eq(0)').text().trim(), 'Dashboard');
+  assert.equal(this.$('#navbar .dropdown-menu a:eq(1)').text().trim(), 'Blogs');
+  assert.equal(this.$('#navbar .dropdown-menu a:eq(2)').text().trim(), 'Sign Out');
 });

--- a/tests/unit/helpers/formatted-date-test.js
+++ b/tests/unit/helpers/formatted-date-test.js
@@ -3,8 +3,10 @@ import { module, test } from 'qunit';
 
 module('Unit | Helper | formatted date');
 
-// Replace this with your real tests.
-test('it works', function(assert) {
-  let result = formattedDate([42]);
-  assert.ok(result);
+test('formats datetime to "month day, year" if "LL" format option is used', function(assert) {
+  assert.expect(1);
+
+  let date = formattedDate(['2007-07-07 00:00:00'], { format: 'LL'});
+
+  assert.equal(date, 'July 7, 2007');
 });

--- a/tests/unit/helpers/moment-date-test.js
+++ b/tests/unit/helpers/moment-date-test.js
@@ -3,8 +3,28 @@ import { module, test } from 'qunit';
 
 module('Unit | Helper | moment date');
 
-// Replace this with your real tests.
-test('it works', function(assert) {
-  let result = momentDate([42]);
-  assert.ok(result);
+test('formats date with moment JS using "second" as "startOf" option "fromNow"', function(assert) {
+  assert.expect(9);
+
+  let dateNow = new Date();
+  let timeNow = dateNow.getSeconds();
+  let secondsAgo = momentDate([dateNow.setSeconds(timeNow - 7)], { format: 'second'});
+  let minuteAgo = momentDate([dateNow.setSeconds(timeNow - 60)], { format: 'second'});
+  let minutesAgo = momentDate([dateNow.setSeconds(timeNow - 90)], { format: 'second'});
+  let hourAgo = momentDate([dateNow.setSeconds(timeNow - 3600)], { format: 'second'});
+  let hoursAgo = momentDate([dateNow.setSeconds(timeNow - 7200)], { format: 'second'});
+  let dayAgo = momentDate([dateNow.setSeconds(timeNow - (3600 * 24))], { format: 'second'});
+  let daysAgo = momentDate([dateNow.setSeconds(timeNow - (3600 * 24 * 3))], { format: 'second'});
+  let monthAgo = momentDate([dateNow.setSeconds(timeNow - (3600 * 24 * 31))], { format: 'second'});
+  let monthsAgo = momentDate([dateNow.setSeconds(timeNow - (3600 * 24 * 200))], { format: 'second'});
+
+  assert.equal(secondsAgo, 'a few seconds ago');
+  assert.equal(minuteAgo, 'a minute ago');
+  assert.equal(minutesAgo, '3 minutes ago');
+  assert.equal(hourAgo, 'an hour ago');
+  assert.equal(hoursAgo, '3 hours ago');
+  assert.equal(dayAgo, 'a day ago');
+  assert.equal(daysAgo, '4 days ago');
+  assert.equal(monthAgo, 'a month ago');
+  assert.equal(monthsAgo, '8 months ago');
 });

--- a/tests/unit/helpers/truncate-text-test.js
+++ b/tests/unit/helpers/truncate-text-test.js
@@ -3,8 +3,11 @@ import { module, test } from 'qunit';
 
 module('Unit | Helper | truncate text');
 
-// Replace this with your real tests.
-test('it works', function(assert) {
-  let result = truncateText([42]);
-  assert.ok(result);
+test('truncates long text if "length" option is defined', function(assert) {
+  assert.expect(1);
+
+  let text = '&lt;p&gt;The quick brown fox jumps over the lazy dog.&lt;/p&gt;';
+  let newText = truncateText([text], { length: 20 });
+
+  assert.equal(newText, 'The quick brown fox...');
 });

--- a/tests/unit/helpers/unescape-html-test.js
+++ b/tests/unit/helpers/unescape-html-test.js
@@ -3,8 +3,11 @@ import { module, test } from 'qunit';
 
 module('Unit | Helper | unescape html');
 
-// Replace this with your real tests.
-test('it works', function(assert) {
-  let result = unescapeHtml([42]);
-  assert.ok(result);
+test('parses the HTML tags from a text', function(assert) {
+  assert.expect(1);
+
+  let text = '&lt;p&gt;This text is wrapped with a paragraph tag.&lt;/p&gt;';
+  let newText = unescapeHtml([text]);
+
+  assert.equal(newText, '<p>This text is wrapped with a paragraph tag.</p>');
 });


### PR DESCRIPTION
## Developers Note

The Ember tests for Foodie Client shall be placed on a separate branch – `ember-tests`. Some of the component tests are using the `ember-data-factory-guy` however the stable version (`2.7.10`) causes the `service:session` to be empty. Even the recently released version of the `ember-data-factory-guy 2.8.0` still causes the same error. See the screenshots below:

From `node_modules/ember-data-factory-guy/addon/utils/manual-setup.js`:

![screen shot 2016-09-28 at 8 39 45 pm](https://cloud.githubusercontent.com/assets/6590336/18913827/a4d24028-85bc-11e6-94df-9ca4af6c750d.png)

Error from Chrome inspector:

![screen shot 2016-09-28 at 8 41 09 pm](https://cloud.githubusercontent.com/assets/6590336/18913829/b0740f1a-85bc-11e6-87e0-cbeefa76b4d2.png)

And the `service:session` used by `ember-simple-auth`:

![screen shot 2016-09-28 at 8 42 21 pm](https://cloud.githubusercontent.com/assets/6590336/18913835/b96821ce-85bc-11e6-98d4-310c39613187.png)

**Tests completed:**

• All helpers
• Activity Streams
• Activity Streams Item

With `ember-data-factory-guy` node module:
• Admin Blog Form
